### PR TITLE
fix(canary): use SIGALRM for hard wall-clock per-query timeout

### DIFF
--- a/scripts/online_canary.py
+++ b/scripts/online_canary.py
@@ -26,6 +26,15 @@ import sys
 import time
 from pathlib import Path
 
+class _QueryTimeoutError(Exception):
+    """Raised by SIGALRM when a canary query exceeds its wall-clock budget."""
+    pass
+
+
+def _sigalrm_handler(signum, frame):
+    raise _QueryTimeoutError("SIGALRM: wall-clock timeout")
+
+
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 
@@ -347,21 +356,27 @@ async def main():
         print(f"   {query['question'][:80]}...")
         print(f"{'─' * 60}")
 
+        # Use SIGALRM for hard wall-clock timeout — works even when
+        # synchronous time.sleep() calls in LLM providers block the event loop.
+        import signal
+        old_handler = signal.signal(signal.SIGALRM, _sigalrm_handler)
+        signal.alarm(QUERY_TIMEOUT_SECONDS)
         try:
-            result = await asyncio.wait_for(
-                run_single_query(query, provider, provider_name, output_dir),
-                timeout=QUERY_TIMEOUT_SECONDS,
-            )
-        except asyncio.TimeoutError:
+            result = await run_single_query(query, provider, provider_name, output_dir)
+        except _QueryTimeoutError:
             result = {
                 "query_id": query["id"],
                 "question": query["question"],
                 "run_id": f"canary_{query['id'].lower()}",
                 "status": "FAIL",
-                "error": f"Query timed out after {QUERY_TIMEOUT_SECONDS}s",
+                "error": f"Query timed out after {QUERY_TIMEOUT_SECONDS}s (wall-clock SIGALRM)",
                 "warnings": [],
                 "metrics": {},
             }
+            print(f"  ⏰ SIGALRM: query killed after {QUERY_TIMEOUT_SECONDS}s", flush=True)
+        finally:
+            signal.alarm(0)  # Cancel the alarm
+            signal.signal(signal.SIGALRM, old_handler)
         query_results.append(result)
 
         status_icon = "✅" if result["status"] == "PASS" else "❌"


### PR DESCRIPTION
## Problem

Follow-up to #33 and #34. Canary runs #8 and #9 both timed out at 45 minutes despite the `asyncio.wait_for(timeout=480)` added in #34.

## Root Cause — Why asyncio.wait_for Doesn't Work

The CDR pipeline calls **`provider.complete()`** (synchronous) — not `acomplete()` (async) — in **10+ nodes**:

| Node | File | Method |
|------|------|--------|
| Screener | `screener.py` | `provider.complete()` |
| Composer | `composer.py` | `provider.complete()` (×3) |
| Skeptic | `skeptic_agent.py` | `provider.complete()` (×3) |
| RoB2 | `assessor.py` | `provider.complete()` |
| ROBINS-I | `robins_i_assessor.py` | `provider.complete()` |
| Verifier | `verifier.py` | `provider.complete()` (×2) |
| Extractor | `extractor.py` | `provider.complete()` |

The sync `complete()` method in `groq_provider.py` uses `time.sleep()` for TPD (tokens-per-day) retries:

```python
# groq_provider.py line 170 — blocks the event loop!
time.sleep((wait_minutes + 1) * 60)  # 12-20 min sleeps
```

This blocks the asyncio event loop entirely — `asyncio.wait_for` never gets a chance to raise `TimeoutError`.

## Failure Sequence (Run #9 logs)

```
12:28:47 ✅ Using provider: groq         (health-check passed)
12:28:47 📋 Query 1/5: CQ-001
12:30:42 ✅ PASS  latency=113.1s          (consumed most of Groq TPD)
12:30:42 📋 Query 2/5: CQ-002
12:31:03 [Groq] Daily limit (TPD) hit. Waiting 12 minutes...
12:43:04 [Groq] Daily limit (TPD) hit. Waiting 20 minutes...
13:03:07 [Groq] Daily limit (TPD) hit. Waiting 7 minutes...
13:13:30 ❌ Job killed by 45-min timeout
```

The 8-min `asyncio.wait_for` should have fired at 12:38:42 — but it couldn't because `time.sleep(720)` was blocking the event loop.

## Fix

Replace `asyncio.wait_for` with `signal.alarm(SIGALRM)`:

```python
signal.alarm(QUERY_TIMEOUT_SECONDS)  # 480s = 8 min
try:
    result = await run_single_query(...)
except _QueryTimeoutError:
    result = {..., "status": "FAIL", "error": "timed out"}
finally:
    signal.alarm(0)
```

SIGALRM is delivered by the OS kernel — it interrupts `time.sleep()`, `select()`, and any other blocking syscall, raising `_QueryTimeoutError` which the canary catches gracefully.

## Impact
- Zero changes to the main CDR pipeline
- Canary queries that hang (any reason) are now killed after 8 minutes
- Remaining queries still execute after a timeout
- Health-check retains `asyncio.wait_for` (uses async `acomplete()`, not affected)